### PR TITLE
Add "nodethon" container (Python+Node.js in tox env)

### DIFF
--- a/nodethon/Dockerfile
+++ b/nodethon/Dockerfile
@@ -1,0 +1,22 @@
+#
+# Builds a docker image with Python and Node.js to use for tox runs.
+#
+FROM ubuntu:18.04
+
+VOLUME /repo
+
+WORKDIR /repo
+
+
+ENV SONAR_SCANNER_VERSION 4.2.0.1873
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
+ENV SONAR_SCANNER_HOME=/sonar-scanner-${SONAR_SCANNER_VERSION}-linux
+ENV SONAR_SCANNER_OPTS="-server"
+
+ENV PATH="${SONAR_SCANNER_HOME}/sonar-scanner-${SONAR_SCANNER_VERSION}-linux/bin:${PATH}"
+
+COPY provision.sh /
+
+RUN /provision.sh

--- a/nodethon/README.md
+++ b/nodethon/README.md
@@ -1,8 +1,8 @@
 # "Nodethon" (Node.js + Python) Docker
 
-Builds and pushes a docker environment for use with tox testing. This environment contains Node.js 13 and some other JavaScript dependencies, besides a series of python versions allowing multi-version tox testing locally and in CI services.
+Builds and pushes a docker environment useful for testing and building Node.js applications that also use Python or Python applications that also use Node.js. This environment contains Node.js and a few other, essential JavaScript dependencies as well as series of python versions allowing multi-version tox testing locally and in CI services.
 
-The "sq" suffix indicates that the ["sonarqube"](https://www.sonarqube.org) scanner has been included in the image. This scanner allows tox builds to upload coverage and other reports to a sonarqube instance.
+All nodethon images include the ["sonarqube"](https://www.sonarqube.org) scanner. This scanner allows node and tox builds to upload coverage and analysis reports to a sonarqube instance.
 
 ## Build and Push
 

--- a/nodethon/README.md
+++ b/nodethon/README.md
@@ -1,0 +1,72 @@
+# "Nodethon" (Node.js + Python) Docker
+
+Builds and pushes a docker environment for use with tox testing. This environment contains Node.js 13 and some other JavaScript dependencies, besides a series of python versions allowing multi-version tox testing locally and in CI services.
+
+The "sq" suffix indicates that the ["sonarqube"](https://www.sonarqube.org) scanner has been included in the image. This scanner allows tox builds to upload coverage and other reports to a sonarqube instance.
+
+## Build and Push
+
+These instructions are for maintainers with permissions to push to the "uavcan" organization on Docker Hub.
+
+```
+docker build .
+```
+```
+docker images
+
+REPOSITORY      TAG            IMAGE ID
+nodethon        latest         d7ab132649d6
+```
+```
+# We use the range of python environments supported as the version tag.
+docker tag d7ab132649d6 uavcan/nodethon:py35-py38-node13-sq
+docker login --username=yourhubusername
+docker push uavcan/nodethon:py35-py38-node13-sq
+```
+
+## Testing out the container
+
+Start an interactive session:
+
+```bash
+docker run --rm -it -v ${PWD}:/repo uavcan/nodethon:py35-py38-node13-sq
+```
+
+On MacOS you'll probably want to optimize `osxfs` with something like cached or delegated:
+
+```bash
+docker run --rm -it -v ${PWD}:/repo:delegated uavcan/nodethon:py35-py38-node13-sq
+```
+
+See ["Performance tuning for volume mounts"](https://docs.docker.com/docker-for-mac/osxfs-caching/) for details.
+
+## Travis CI
+
+You can use this in your .travis.yml like this:
+
+```none
+services:
+  - docker
+
+before_install:
+- docker pull uavcan/nodethon:py35-py38-node13-sq
+
+script:
+- docker run --rm -v $TRAVIS_BUILD_DIR:/repo uavcan/nodethon:py35-py38-node13-sq /bin/sh -c tox
+
+```
+
+## BuildKite
+
+Example pipeline.yml:
+
+```yaml
+- label: ":github: my containerized build"
+    command: "nodethon tox"
+    plugins:
+      - docker#v3.5.0:
+          workdir: /repo
+          image: "uavcan/nodethon:py35-py38-node13-sq"
+          propagate-environment: true
+          mount-ssh-agent: true
+```

--- a/nodethon/README.md
+++ b/nodethon/README.md
@@ -2,7 +2,7 @@
 
 Builds and pushes a docker environment useful for testing and building Node.js applications that also use Python or Python applications that also use Node.js. This environment contains Node.js and a few other, essential JavaScript dependencies as well as series of python versions allowing multi-version tox testing locally and in CI services.
 
-All nodethon images include the ["sonarqube"](https://www.sonarqube.org) scanner. This scanner allows node and tox builds to upload coverage and analysis reports to a sonarqube instance.
+All *nodethon* images include the ["sonarqube"](https://www.sonarqube.org) scanner. This scanner allows node and tox builds to upload coverage and analysis reports to a sonarqube instance.
 
 ## Build and Push
 
@@ -19,9 +19,9 @@ nodethon        latest         d7ab132649d6
 ```
 ```
 # We use the range of python environments supported as the version tag.
-docker tag d7ab132649d6 uavcan/nodethon:py35-py38-node13-sq
+docker tag d7ab132649d6 uavcan/nodethon:node13-py37-py38
 docker login --username=yourhubusername
-docker push uavcan/nodethon:py35-py38-node13-sq
+docker push uavcan/nodethon:node13-py37-py38
 ```
 
 ## Testing out the container
@@ -29,13 +29,13 @@ docker push uavcan/nodethon:py35-py38-node13-sq
 Start an interactive session:
 
 ```bash
-docker run --rm -it -v ${PWD}:/repo uavcan/nodethon:py35-py38-node13-sq
+docker run --rm -it -v ${PWD}:/repo uavcan/nodethon:node13-py37-py38
 ```
 
 On MacOS you'll probably want to optimize `osxfs` with something like cached or delegated:
 
 ```bash
-docker run --rm -it -v ${PWD}:/repo:delegated uavcan/nodethon:py35-py38-node13-sq
+docker run --rm -it -v ${PWD}:/repo:delegated uavcan/nodethon:node13-py37-py38
 ```
 
 See ["Performance tuning for volume mounts"](https://docs.docker.com/docker-for-mac/osxfs-caching/) for details.
@@ -49,10 +49,10 @@ services:
   - docker
 
 before_install:
-- docker pull uavcan/nodethon:py35-py38-node13-sq
+- docker pull uavcan/nodethon:node13-py37-py38
 
 script:
-- docker run --rm -v $TRAVIS_BUILD_DIR:/repo uavcan/nodethon:py35-py38-node13-sq /bin/sh -c tox
+- docker run --rm -v $TRAVIS_BUILD_DIR:/repo uavcan/nodethon:node13-py37-py38 /bin/sh -c tox
 
 ```
 
@@ -66,7 +66,7 @@ Example pipeline.yml:
     plugins:
       - docker#v3.5.0:
           workdir: /repo
-          image: "uavcan/nodethon:py35-py38-node13-sq"
+          image: "uavcan/nodethon:node13-py37-py38"
           propagate-environment: true
           mount-ssh-agent: true
 ```

--- a/nodethon/provision.sh
+++ b/nodethon/provision.sh
@@ -46,6 +46,16 @@ apt-get -y install python3.8
 apt-get -y install python3-pip
 pip3 install tox
 
+# Node.js (13), npm (6.14) and JS dependencies
+curl -sL https://deb.nodesource.com/setup_13.x | sudo -E bash -
+apt-get -y install nodejs
+node -v
+npm -v
+# install JSdoc to be used with sphinx-js
+npm install -g jsdoc
+# install Mocha JavaScript test framework
+npm install -g mocha
+
 # Sonarqube
 curl --create-dirs -sSLo $HOME/.sonar/sonar-scanner.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-$SONAR_SCANNER_VERSION-linux.zip
 unzip -o $HOME/.sonar/sonar-scanner.zip -d $SONAR_SCANNER_HOME

--- a/nodethon/provision.sh
+++ b/nodethon/provision.sh
@@ -39,8 +39,6 @@ apt-get -y install unzip
 # deadsnakes maintains a bunch of python versions for Ubuntu.
 add-apt-repository -y ppa:deadsnakes/ppa
 apt-get update
-apt-get -y install python3.5
-apt-get -y install python3.6
 apt-get -y install python3.7
 apt-get -y install python3.8
 apt-get -y install python3-pip


### PR DESCRIPTION
In order to run `sphinx-js` and Mocha JS test framework (besides running Yukon overall), we require the container to have npm installed and these dependencies.